### PR TITLE
Fetch all schema versions

### DIFF
--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -68,6 +68,8 @@ SchemaRegistry.prototype.init = Promise.method(function () {
 
   return this._fetchAllSchemaTopics()
     .bind(this)
+    .map(this._fetchSchemaVersions, {concurrency: 10})
+    .then(schemaVersions => [].concat(...schemaVersions)) // Flatten
     .map(this._fetchSchema, {concurrency: 10})
     .map(this._registerSchema);
 });
@@ -96,19 +98,48 @@ SchemaRegistry.prototype._fetchAllSchemaTopics = Promise.method(function () {
 });
 
 /**
+ * Fetch all available versions for a subject from the SR.
+ *
+ * @return {Promise(Array.<Object>)} A Promise with an array of objects
+ *   containing the topic name and version number.
+ * @private
+ */
+SchemaRegistry.prototype._fetchSchemaVersions = Promise.method(function (schemaTopic) {
+  var fetchVersionsUrl = url.resolve(this.schemaRegistryUrl,
+    '/subjects/' + schemaTopic + '/versions');
+
+  log.debug('_fetchSchemaVersions() :: Fetching schema versions:',
+    fetchVersionsUrl);
+
+  return Promise.resolve(axios.get(fetchVersionsUrl))
+    .then((response) => {
+      log.debug('_fetchSchemaVersions() :: Fetched schema versions:',
+        fetchVersionsUrl);
+
+      return response.data.concat('latest').map(version => ({
+        version: version,
+        schemaTopic: schemaTopic,
+      }));
+    })
+    .catch(this._handleAxiosError);
+});
+
+/**
  * Fetch a single schema from the SR and return its value along with metadata.
  *
  * @return {Promise(Array.<Object>)} A Promise with an array of objects,
  *   see return statement bellow for return schema.
  * @private
  */
-SchemaRegistry.prototype._fetchSchema = Promise.method(function (schemaTopic) {
+SchemaRegistry.prototype._fetchSchema = Promise.method(function (topicMeta) {
+  var schemaTopic = topicMeta.schemaTopic;
+  var version = topicMeta.version;
   var parts = schemaTopic.split('-');
   var schemaType = parts.pop();
   var topic = parts.join('-');
 
   var fetchSchemaUrl = url.resolve(this.schemaRegistryUrl,
-    '/subjects/' + schemaTopic + '/versions/latest');
+    '/subjects/' + schemaTopic + '/versions/' + version);
 
   log.debug('_fetchSchema() :: Fetching schema url:',
     fetchSchemaUrl);
@@ -119,6 +150,7 @@ SchemaRegistry.prototype._fetchSchema = Promise.method(function (schemaTopic) {
         fetchSchemaUrl);
 
       return {
+        version: version,
         responseRaw: response.data,
         schemaType: schemaType,
         schemaTopicRaw: schemaTopic,
@@ -152,10 +184,14 @@ SchemaRegistry.prototype._registerSchema = Promise.method(function (schemaObj) {
 
   if (schemaObj.schemaType.toLowerCase() === 'value') {
     this.schemaTypeById['schema-' + schemaObj.responseRaw.id] = schemaObj.type;
-    this.valueSchemas[schemaObj.topic] = schemaObj.type;
-    this.schemaMeta[schemaObj.topic] = schemaObj.responseRaw;
+    if (schemaObj.version === 'latest') {
+      this.valueSchemas[schemaObj.topic] = schemaObj.type;
+      this.schemaMeta[schemaObj.topic] = schemaObj.responseRaw;
+    }
   } else {
-    this.keySchemas[schemaObj.topic] = schemaObj.type;
+    if (schemaObj.version === 'latest') {
+      this.keySchemas[schemaObj.topic] = schemaObj.type;
+    }
   }
   return schemaObj;
 });

--- a/test/spec/schema-registry.test.js
+++ b/test/spec/schema-registry.test.js
@@ -18,6 +18,7 @@ describe('Initialization of SR', function() {
     return sr.init()
       .map((res) => {
         expect(res).to.have.keys([
+          'version',
           'responseRaw',
           'schemaType',
           'topic',
@@ -42,6 +43,7 @@ describe('Initialization of SR', function() {
     return sr.init()
       .map((res) => {
         if (res.schemaType.toLowerCase() === 'value') {
+          expect(sr.schemaTypeById['schema-' + res.responseRaw.id]).to.be.an('object');
           expect(sr.valueSchemas[res.topic]).to.be.an('object');
           expect(sr.schemaMeta[res.topic]).to.be.an('object');
 

--- a/test/spec/schema-registry.test.js
+++ b/test/spec/schema-registry.test.js
@@ -21,7 +21,6 @@ describe('Initialization of SR', function() {
           'responseRaw',
           'schemaType',
           'topic',
-          'schemaRaw',
           'schemaTopicRaw',
           'type',
         ]);


### PR DESCRIPTION
Hi!

This change makes SchemaRegistry fetch all versions of each schema.

A little bit of background:

During development of an internal feature we accidentally produced a backwards-incompatible version of a topic schema. The clients producing messages on this topic were still working as expected because they were using a bundled schema (a Java bean generated based on the schema source). The schema ID they were using was one "behind" the latest version. Deserialisation was failing in our node-app (using kafka-avro) because we were attempting to use the latest schema version (correctly read from the magic bytes, but defaulting to the "current" schema since the ID wasn't resolving to a specific schema).

My proposal is to fetch all version of every schema and put them in the ID-to-schema map (`SchemaRegistry#schemaTypeById`), but still defaulting to "latest" in the subject maps (`valueSchemas` and `schemaMeta`). The consequence of this change is increased startup time. Depending on how often you publish new versions, this may result in an order of magnitude performance regression. If you think this change looks ok I can start looking into #14 since it doesn't look like any progress has been made by the reporter.

About the code:

`SchemaRegistry` has been changed to fetch all available versions of a schema before fetching the actual schema data. Instead of doing one request per subject, it now does one per version (+ latest), per subject. We explicitly fetch "latest" because there's no way of knowing from `/versions` what is the latest schema version.

I tried to keep the code style as close as possible to the rest of the code base. I couldn't reliably run the test locally (to my understanding it was failing somewhere in node-rdkafka). I disabled all tests apart from the SR tests to verify that my changes were still working (I had to update one test to make master pass first). Since we can't assert on any data in the kafka image it was hard to get full coverage. Let me know if there's a way to push new schema versions for testing.