### PR TITLE
Allow customization of avsc parse options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When instantiating kafka-avro you may pass the following options:
 * `schemaRegistry` **String REQUIRED** The url to the Schema Registry.
 * `topics` **Array of Strings** You may optionally define specific topics to be fetched by kafka-avro vs fetching schemas for all the topics which is the default behavior.
 * `fetchAllVersions` **Boolean** Set to true to fetch all versions for each topic, use it when updating of schemas is often in your environment.
+* `parseOptions` **Object** Schema parse options to pass to `avro.parse()`. `parseOptions.wrapUnions` is set to `true` by default.
 
 ### Producer
 

--- a/lib/kafka-avro.js
+++ b/lib/kafka-avro.js
@@ -45,6 +45,7 @@ var KafkaAvro = module.exports = CeventEmitter.extend(function(opts) {
     schemaRegistryUrl: opts.schemaRegistry,
     selectedTopics: opts.topics || null,
     fetchAllVersions: opts.fetchAllVersions || false,
+    parseOptions: opts.parseOptions,
   };
 
   /** @type {kafka-avro.SchemaRegistry} Instanciated SR. */

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -18,6 +18,7 @@ var log = rootLog.getChild(__filename);
  *   @param {string} schemaRegistryUrl The SR url.
  *   @param {Array.<string>|null} selectedTopics Selected topics to fetch if defined.
  *   @param {boolean} fetchAllVersions Fetch all past versions for each topic.
+ *   @param {?Object} parseOptions Schema parsing options to pass to avro.parse().
  * @constructor
  */
 var SchemaRegistry = module.exports = cip.extend(function(opts) {
@@ -32,6 +33,12 @@ var SchemaRegistry = module.exports = cip.extend(function(opts) {
 
   /** @type {?Array.<string>} List of schema topics with -value, -key annotations */
   this.schemaTopics = null;
+
+  /** @type {?Object} Schema parsing options to pass to avro.parse() */
+  this.parseOptions = opts.parseOptions || {};
+  if (this.parseOptions.wrapUnions === undefined) {
+    this.parseOptions.wrapUnions = true;
+  }
 
   /**
    * A dict containing all the value schemas with key the bare topic name and
@@ -308,7 +315,7 @@ SchemaRegistry.prototype._registerSchema = Promise.method(function (schemaObj) {
     schemaObj.topic);
 
   try {
-    schemaObj.type = avro.parse(schemaObj.responseRaw.schema, {wrapUnions: true});
+    schemaObj.type = avro.parse(schemaObj.responseRaw.schema, this.parseOptions);
   } catch(ex) {
     log.warn('_registerSchema() :: Error parsing schema:',
       schemaObj.schemaTopicRaw, 'Error:', ex.message, 'Moving on...');
@@ -337,7 +344,7 @@ SchemaRegistry.prototype._registerSchemaLatest = Promise.method(function (schema
     schemaObj.topic);
 
   try {
-    schemaObj.type = avro.parse(schemaObj.responseRaw.schema, { wrapUnions: true });
+    schemaObj.type = avro.parse(schemaObj.responseRaw.schema, this.parseOptions);
   } catch (ex) {
     log.warn('_registerSchemaLatest() :: Error parsing schema:',
       schemaObj.schemaTopicRaw, 'Error:', ex.message, 'Moving on...');


### PR DESCRIPTION
I needed `wrapUnions: false`, so I made parsing options customizable.