### PR TITLE
Using schema registry url as URL object

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,12 @@ Deserialize the provided message, expects a message that includes Magic Byte and
 
 ## Release History
 
+- **1.0.2**, *23 Apr 2018*
+    - Using URL module instead of strings to resolve schema registry urls.(by [ricardohbin](https://github.com/ricardohbin))
 - **1.0.1**, *03 Apr 2018*
-    - **Breaking change**: New consumer stream API, changes in producer and fixing all integration tests thank you [ricardohbin](https://github.com/ricardohbin))
+    - **Breaking change**: New consumer stream API, changes in producer and fixing all integration tests (by [ricardohbin](https://github.com/ricardohbin)).
 - **1.0.0**, *28 Mar 2018*
-    - Updating docs and the libs avsc (v5.2.3) and node-rdkafka (v2.1.3) (thank you [ricardohbin](https://github.com/ricardohbin))
+    - Updating docs and the libs avsc (v5.2.3) and node-rdkafka (v2.1.3) (by [ricardohbin](https://github.com/ricardohbin)).
 - **v0.8.1**, *01 Feb 2018*
     - Allow customization of AVSC parse options (thank you [dapetcu21](https://github.com/dapetcu21)).
 - **v0.8.0**, *27 Nov 2017*

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Queries the Schema Registry for all schemas and evaluates them.
  */
-var url = require('url');
+var URL = require('url').URL;
 
 var Promise = require('bluebird');
 var cip = require('cip');
@@ -22,8 +22,8 @@ var log = rootLog.getChild(__filename);
  * @constructor
  */
 var SchemaRegistry = module.exports = cip.extend(function(opts) {
-  /** @type {string} The SR url */
-  this.schemaRegistryUrl = opts.schemaRegistryUrl;
+  /** @type {Object} The SR URL object */
+  this.schemaRegistryUrl = new URL(opts.schemaRegistryUrl);
 
   /** @type {Array.<string>|null} The user selected topics to fetch, can be null */
   this.selectedTopics = opts.selectedTopics;
@@ -194,7 +194,7 @@ SchemaRegistry.prototype._processSelectedTopics = Promise.method(function () {
  */
 SchemaRegistry.prototype._fetchAllSchemaTopics = Promise.method(function () {
 
-  var fetchAllTopicsUrl = url.resolve(this.schemaRegistryUrl, '/subjects');
+  var fetchAllTopicsUrl = new URL('/subjects', this.schemaRegistryUrl).toString();
 
   log.debug('_fetchAllSchemaTopics() :: Fetching all schemas using url:',
     fetchAllTopicsUrl);
@@ -218,8 +218,10 @@ SchemaRegistry.prototype._fetchAllSchemaTopics = Promise.method(function () {
  * @private
  */
 SchemaRegistry.prototype._fetchLatestVersion = Promise.method(function (schemaTopic) {
-  var fetchLatestVersionUrl = url.resolve(this.schemaRegistryUrl,
-    '/subjects/' + schemaTopic + '/versions/latest');
+  var fetchLatestVersionUrl = new URL(
+    '/subjects/' + schemaTopic + '/versions/latest',
+    this.schemaRegistryUrl
+  ).toString();
 
   log.debug('_fetchLatestVersion() :: Fetching latest topic version from url:',
     fetchLatestVersionUrl);
@@ -246,8 +248,10 @@ SchemaRegistry.prototype._fetchLatestVersion = Promise.method(function (schemaTo
  * @private
  */
 SchemaRegistry.prototype._fetchAllSchemaVersions = Promise.method(function (schemaTopic) {
-  var fetchVersionsUrl = url.resolve(this.schemaRegistryUrl,
-    '/subjects/' + schemaTopic + '/versions');
+  var fetchVersionsUrl = new URL(
+    '/subjects/' + schemaTopic + '/versions',
+    this.schemaRegistryUrl
+  ).toString();
 
   log.debug('_fetchAllSchemaVersions() :: Fetching schema versions:',
     fetchVersionsUrl);
@@ -280,8 +284,10 @@ SchemaRegistry.prototype._fetchSchema = Promise.method(function (topicMeta) {
   var schemaType = parts.pop();
   var topic = parts.join('-');
 
-  var fetchSchemaUrl = url.resolve(this.schemaRegistryUrl,
-    '/subjects/' + schemaTopic + '/versions/' + version);
+  var fetchSchemaUrl = new URL(
+    '/subjects/' + schemaTopic + '/versions/' + version,
+    this.schemaRegistryUrl
+  ).toString();
 
   log.debug('_fetchSchema() :: Fetching schema url:',
     fetchSchemaUrl);
@@ -402,6 +408,3 @@ SchemaRegistry.prototype._suppressAxiosError = function (err) {
 
   return null;
 };
-
-
-

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "name": "Thanasis Polychronakis",
     "email": "thanpolas@gmail.com"
   },
-  "contributors": [
-    ""
-  ],
+  "contributors": [{
+    "name": "Ricardo Bin",
+    "email": "ricardohbin@gmail.com"
+  }],
   "repository": {
     "type": "git",
     "url": "https://github.com/waldophotos/kafka-avro"


### PR DESCRIPTION
There's some problems with url.resolve: when there's no protocol, the resolved url lost the domain. 
Ex:
```
url.resolve("domain.com","some") //some
```

Using URL we avoid all kind of these problems, if the user doesn't put protocol, throws URL TypeError.

This solves https://github.com/waldophotos/kafka-avro/issues/15

What do you think @thanpolas ? All integration tests are ok.