### PR TITLE
Adding paths to Schema-Registry URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
 
 ## Release History
 
+- **1.0.4**, *30 May 2018*
+    - Allowing schema-registry urls with paths (by [941design](https://github.com/941design))
 - **1.0.3**, *28 May 2018*
     - Added support for providing configured https.Agent to support schema-registry using private certificates. (by [scottchapman](https://github.com/scottchapman))
 - **1.0.2**, *23 Apr 2018*

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -27,7 +27,7 @@ var SchemaRegistry = module.exports = cip.extend(function(opts) {
   }
 
   /** @type {Object} The SR URL object */
-  this.schemaRegistryUrl = new URL(opts.schemaRegistryUrl);
+  this.schemaRegistryUrl = new URL(opts.schemaRegistryUrl + (opts.schemaRegistryUrl.endsWith('/') ? '' : '/'));
 
   /** @type {Array.<string>|null} The user selected topics to fetch, can be null */
   this.selectedTopics = opts.selectedTopics;
@@ -198,7 +198,7 @@ SchemaRegistry.prototype._processSelectedTopics = Promise.method(function () {
  */
 SchemaRegistry.prototype._fetchAllSchemaTopics = Promise.method(function () {
 
-  var fetchAllTopicsUrl = new URL('/subjects', this.schemaRegistryUrl).toString();
+  var fetchAllTopicsUrl = new URL('subjects', this.schemaRegistryUrl).toString();
 
   log.debug('_fetchAllSchemaTopics() :: Fetching all schemas using url:',
     fetchAllTopicsUrl);
@@ -223,7 +223,7 @@ SchemaRegistry.prototype._fetchAllSchemaTopics = Promise.method(function () {
  */
 SchemaRegistry.prototype._fetchLatestVersion = Promise.method(function (schemaTopic) {
   var fetchLatestVersionUrl = new URL(
-    '/subjects/' + schemaTopic + '/versions/latest',
+    'subjects/' + schemaTopic + '/versions/latest',
     this.schemaRegistryUrl
   ).toString();
 
@@ -253,7 +253,7 @@ SchemaRegistry.prototype._fetchLatestVersion = Promise.method(function (schemaTo
  */
 SchemaRegistry.prototype._fetchAllSchemaVersions = Promise.method(function (schemaTopic) {
   var fetchVersionsUrl = new URL(
-    '/subjects/' + schemaTopic + '/versions',
+    'subjects/' + schemaTopic + '/versions',
     this.schemaRegistryUrl
   ).toString();
 
@@ -289,7 +289,7 @@ SchemaRegistry.prototype._fetchSchema = Promise.method(function (topicMeta) {
   var topic = parts.join('-');
 
   var fetchSchemaUrl = new URL(
-    '/subjects/' + schemaTopic + '/versions/' + version,
+    'subjects/' + schemaTopic + '/versions/' + version,
     this.schemaRegistryUrl
   ).toString();
 


### PR DESCRIPTION
* concatenation of URL objects has some peculiarities we need to cope with

* regression introduced with https://github.com/waldophotos/kafka-avro/commit/879d0eb6b5192e621638bee17d3ee8b20c930464

`new URL('baz', new URL('http://foo/bar/')).toString() # 'http://foo/bar/baz`
but
`new URL('/baz', new URL('http://foo/bar/')).toString()  # 'http://foo/baz`
