### PR TITLE
Support for different reader and writer schemas on consumption

### DIFF
--- a/lib/kafka-avro.js
+++ b/lib/kafka-avro.js
@@ -41,6 +41,9 @@ var KafkaAvro = module.exports = CeventEmitter.extend(function(opts) {
   /** @type {string} The SR url */
   this.kafkaBrokerUrl = opts.kafkaBroker;
 
+  /** @type {Map.<avsc.Type>} optional reader schemas */
+  this.readerSchemaByTopic = opts.readerSchemaByTopic || { };
+
   var srOpts = {
     schemaRegistryUrl: opts.schemaRegistry,
     selectedTopics: opts.topics || null,

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -112,8 +112,10 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
       return;
     }
 
-    var type = this.sr.valueSchemas[message.topic];
-    var decoded = this.deserialize(type, message);
+    var writerType = this.sr.valueSchemas[message.topic];
+    var readerType = this.readerSchemaByTopic[message.topic];
+
+    var decoded = this.deserialize(writerType, message, readerType);
 
     if (!decoded) {
       message.parsed = null;
@@ -130,13 +132,14 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
 /**
  * Deserialize an avro message.
  *
- * @param {avsc.Type} type Avro type instance.
+ * @param {avsc.Type} writerType Avro writer type instance.
  * @param {Object} message The raw message.
+ * @param {avsc.Type} readerType Avro reader type instance.
  * @return {Object} The deserialized object.
  */
-Consumer.prototype.deserialize = function (type, message) {
+Consumer.prototype.deserialize = function (writerType, message, readerType) {
   try {
-    var parsed = magicByte.fromMessageBuffer(type, message.value, this.sr);
+    var parsed = magicByte.fromMessageBuffer(writerType, message.value, this.sr, readerType);
   } catch(ex) {
     log.warn(`deserialize() :: Error deserializing on topic ${ message.topic }`,
       'Raw value:', message.value, `Partition: ${ message.partition } Offset:`,

--- a/lib/magic-byte.js
+++ b/lib/magic-byte.js
@@ -38,14 +38,15 @@ magicByte.toMessageBuffer = function (val, type, schemaId, optLength) {
 /**
  * Decode a confluent SR message with magic byte.
  *
- * @param {avsc.Type} type The topic's Avro decoder.
+ * @param {avsc.Type} writerType The topic's Avro writer schema decoder.
  * @param {Buffer} encodedMessage The incoming message.
  * @param {kafka-avro.SchemaRegistry} sr The local SR instance.
+ * @param {avsc.Type} readerType The topic's Avro reader schema decoded.
  * @return {Object} Object with:
  *   @param {number} schemaId The schema id.
  *   @param {Object} value The decoded avro value.
  */
-magicByte.fromMessageBuffer = function (type, encodedMessage, sr) {
+magicByte.fromMessageBuffer = function (writerType, encodedMessage, sr, readerType) {
   if (encodedMessage[0] !== MAGIC_BYTE) {
     throw new TypeError('Message not serialized with magic byte');
   }
@@ -53,12 +54,15 @@ magicByte.fromMessageBuffer = function (type, encodedMessage, sr) {
   var schemaId = encodedMessage.readInt32BE(1);
 
   var schemaKey = 'schema-' + schemaId;
+
+  var wt = sr.schemaTypeById[schemaKey] || writerType;
   var decoded;
-  if (!sr.schemaTypeById[schemaKey]) {
-    // use default type
-    decoded = type.decode(encodedMessage, 5);
-  } else {
-    decoded = sr.schemaTypeById[schemaKey].decode(encodedMessage, 5);
+  if (readerType) {
+    var resolver = readerType.createResolver(wt);
+    decoded = readerType.decode(encodedMessage, 5, resolver);
+  }
+  else {
+    decoded = wt.decode(encodedMessage, 5);
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-avro",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "./lib/kafka-avro",
   "description": "Node.js bindings for librdkafka with Avro schema serialization.",
   "homepage": "https://github.com/waldophotos/kafka-avro",
@@ -13,6 +13,10 @@
     {
       "name": "Ricardo Bin",
       "email": "ricardohbin@gmail.com"
+    },
+    {
+      "name": "Javier Holguera",
+      "email": "javier.holguera@gmail.com"
     }
   ],
   "repository": {

--- a/test/fixtures/schema-default-value.fix.json
+++ b/test/fixtures/schema-default-value.fix.json
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "testNodeKafkaAvro",
+  "namespace": "test.kafkaAvro",
+  "fields": [{
+    "name": "name",
+    "type": "string"
+  }, {
+    "name": "long",
+    "type": "long"
+  }, {
+    "name": "anotherString",
+    "type": "string",
+    "default": "defaultValue"
+  }]
+}

--- a/test/lib/test.lib.js
+++ b/test/lib/test.lib.js
@@ -39,7 +39,7 @@ var testBoot = false;
  * Require from all test scripts, prepares kafka for testing.
  *
  */
-testLib.init = function() {
+testLib.init = function(readerSchemas) {
   beforeEach(function() {
     if (testBoot) {
       return;
@@ -69,6 +69,7 @@ testLib.init = function() {
     let kafkaAvro = new KafkaAvro({
       kafkaBroker: testLib.KAFKA_BROKER_URL,
       schemaRegistry: testLib.KAFKA_SCHEMA_REGISTRY_URL,
+      readerSchemaByTopic: readerSchemas
     });
 
     testLib.log.info('test.beforeEach 2: Invoking kafkaAvro.init()...');

--- a/test/spec/consumer.reader-schema.test.js
+++ b/test/spec/consumer.reader-schema.test.js
@@ -1,0 +1,170 @@
+/**
+ * @fileOverview Test produce and consume messages using kafka-avro.
+ */
+var crypto = require('crypto');
+
+var Promise = require('bluebird');
+var chai = require('chai');
+var expect = chai.expect;
+
+var testLib = require('../lib/test.lib');
+
+var Avro = require('avsc');
+var schemaFixV2 = require('../fixtures/schema-default-value.fix');
+
+function noop () {}
+
+describe('Consume with reader schema with extra field with a default', function() {
+  var readerSchemas = {};
+  readerSchemas[schemaFixV2.name] = Avro.parse(schemaFixV2);
+  testLib.init(readerSchemas);
+
+  beforeEach(function() {
+    this.consOpts = {
+      'group.id': 'testKafkaAvro' + crypto.randomBytes(20).toString('hex'),
+      'enable.auto.commit': true,
+    };
+
+    testLib.log.info('beforeEach 1 on Consume');
+    return this.kafkaAvro.getConsumer(this.consOpts)
+      .bind(this)
+      .then(function (consumer) {
+        testLib.log.info('beforeEach 1 on Consume: Got consumer');
+        this.consumer = consumer;
+      });
+  });
+
+  beforeEach(function() {
+    testLib.log.info('beforeEach 2 on Consume');
+    return this.kafkaAvro.getProducer({
+      'dr_cb': true,
+    })
+      .bind(this)
+      .then(function (producer) {
+        testLib.log.info('beforeEach 2 on Consume: Got producer');
+        this.producer = producer;
+
+        producer.on('event.log', function(log) {
+          testLib.log.info('producer log:', log);
+        });
+
+        //logging all errors
+        producer.on('error', function(err) {
+          testLib.log.error('Error from producer:', err);
+        });
+
+        producer.on('delivery-report', function(err, report) {
+          testLib.log.info('delivery-report:' + JSON.stringify(report));
+          this.gotReceipt = true;
+        }.bind(this));
+
+        testLib.log.info('beforeEach 2 on Consume: Done');
+
+      });
+  });
+
+  afterEach(function() {
+    testLib.log.info('afterEach 1 on Consume: Disposing...');
+    return this.kafkaAvro.dispose()
+      .then(function() {
+        testLib.log.info('afterEach 1 on Consume: Disposed');
+      });
+  });
+
+  describe('Consumer direct "on"', function() {
+
+    beforeEach(function() {
+      return new Promise(function (resolve, reject) {
+        this.consumer.on('ready', function() {
+          testLib.log.debug('getConsumer() :: Got "ready" event.');
+          resolve();
+        });
+
+        this.consumer.connect({}, function(err) {
+          if (err) {
+            testLib.log.error('getConsumer() :: Connect failed:', err);
+            reject(err);
+            return;
+          }
+          testLib.log.debug('getConsumer() :: Got "connect()" callback.');
+          resolve(); // depend on Promises' single resolve contract.
+        });
+      }.bind(this));
+    });
+
+    it('should produce and consume a message using consume "on" without value in new field using default', function(done) {
+      var produceTime = 0;
+
+      // message doesn't contain the new field, default value will be deserialized instead
+      var message = {
+        name: 'Thanasis',
+        long: 540,
+      };
+
+      // //start consuming messages
+      this.consumer.subscribe([testLib.topic]);
+      this.consumer.consume();
+
+      this.consumer.on('data', function(rawData) {
+        var data = rawData.parsed;
+        var diff = Date.now() - produceTime;
+        testLib.log.info('Produce to consume time in ms:', diff);
+        expect(data).to.have.keys([
+          'name',
+          'long',
+          'anotherString'
+        ]);
+        expect(data.name).to.equal(message.name);
+        expect(data.long).to.equal(message.long);
+        expect(data.anotherString).to.equal('defaultValue');
+
+        done();
+      }.bind(this));
+
+      setTimeout(() => {
+        produceTime = Date.now();
+        this.producer.produce(testLib.topic, -1, message, 'key');
+      }, 10000);
+    });
+
+    it('should produce and consume a message using consume "on" overriding default value in new field', function(done) {
+      var produceTime = 0;
+
+      // Use the evolved schema with the default value as writer schema for the topic
+      testLib.registerSchema(testLib.topic, schemaFixV2).then(
+        () => {
+
+          var message = {
+            name: 'Thanasis',
+            long: 540,
+            anotherString: 'not-your-default' // field whose default will be ignored
+          };
+
+          // //start consuming messages
+          this.consumer.subscribe([testLib.topic]);
+          this.consumer.consume();
+
+          this.consumer.on('data', function(rawData) {
+            var data = rawData.parsed;
+            var diff = Date.now() - produceTime;
+            testLib.log.info('Produce to consume time in ms:', diff);
+            expect(data).to.have.keys([
+              'name',
+              'long',
+              'anotherString'
+            ]);
+            expect(data.name).to.equal(message.name);
+            expect(data.long).to.equal(message.long);
+            expect(data.anotherString).to.equal('not-your-default');
+
+            done();
+          }.bind(this));
+
+          setTimeout(() => {
+            produceTime = Date.now();
+            this.producer.produce(testLib.topic, -1, message, 'key');
+          }, 10000);
+      });
+    });
+  });
+});

--- a/test/spec/magic-byte.test.js
+++ b/test/spec/magic-byte.test.js
@@ -9,6 +9,7 @@ var avro = require('avsc');
 var magicByte = require('../../lib/magic-byte');
 
 var schemaFix = require('../fixtures/schema.fix');
+var schemaWithDefault = require('../fixtures/schema-default-value.fix');
 
 describe('Magic Byte', function() {
 
@@ -45,4 +46,60 @@ describe('Magic Byte', function() {
     expect(decoded.value.long).to.equal(message.long);
     expect(decoded.schemaId).to.equal(schemaId);
   });
+
+  it('should use default value from reader schema when payload does not provide a value', function() {
+    var message = {
+      name: new Array(40).join('0'),
+      long: 540,
+    };
+
+    var schemaId = 109;
+
+    var writerType = avro.parse(schemaFix, {wrapUnions: true});
+    var readerType = avro.parse(schemaWithDefault, {wrapUnions: true});
+
+    var encoded = magicByte.toMessageBuffer(message, writerType, schemaId);
+
+    var decoded = magicByte.fromMessageBuffer(writerType, encoded,
+      {
+      schemaTypeById: {
+        schemaId: schemaId
+        }
+      },
+      readerType);
+
+    expect(decoded.value.name).to.equal(message.name);
+    expect(decoded.value.long).to.equal(message.long);
+    expect(decoded.value.anotherString).to.equal('defaultValue');
+    expect(decoded.schemaId).to.equal(schemaId);
+  });
+
+  it('should override default value from reader schema when payload provides a value', function() {
+    var message = {
+      name: new Array(40).join('0'),
+      long: 540,
+      anotherString: 'not-your-default'
+    };
+
+    var schemaId = 109;
+
+    schemaFix.fields.push({name: 'anotherString', type: 'string' });
+
+    var writerType = avro.parse(JSON.stringify(schemaFix), {wrapUnions: true});
+    var readerType = avro.parse(schemaWithDefault, {wrapUnions: true});
+
+    var encoded = magicByte.toMessageBuffer(message, writerType, schemaId);
+
+    var decoded = magicByte.fromMessageBuffer(writerType, encoded,
+      {
+      schemaTypeById: {
+        schemaId: schemaId
+        }
+      }, readerType);
+
+    expect(decoded.value.name).to.equal(message.name);
+    expect(decoded.value.long).to.equal(message.long);
+    expect(decoded.value.anotherString).to.equal('not-your-default');
+    expect(decoded.schemaId).to.equal(schemaId);
+  })
 });


### PR DESCRIPTION
Enables schema evolution as discussed in [here](https://github.com/mtth/avsc/wiki/Advanced-usage#schema-evolution)

The idea is the following:
1. Messages will be written to Kafka using Avro with a schema (ie. writer schema).
2. Over time, a new backward compatible version of the schema will be used to read (i.e. reader schema).
3. Using a `resolver`, the schema can evolve from the original writer schema to the new reader schema, leveraging new fields with defaults that didn't exist in the original payload.

I have limited experience with Javascript, please feel free to point to anything that is not idiomatic or just flat out wrong.