### PR TITLE
Fixes kafka-producer to pass timestamp and opaque correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
 
 ## Release History
 
+- **1.0.5**, *27 June 2018*
+    - Fixes kafka-producer to pass timestamp and opaque correctly (by [javierholguera](https://github.com/javierholguera))
 - **1.0.4**, *30 May 2018*
     - Allowing schema-registry urls with paths (by [941design](https://github.com/941design))
 - **1.0.3**, *28 May 2018*

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -70,10 +70,11 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts) {
  * @param {number} partition The partition to produce on.
  * @param {Object} value The message.
  * @param {string|number} key The partioning key.
+ * @param {number} timestamp The create time value.
  * @param {*=} optOpaque Pass vars to receipt handler.
  */
 Producer.prototype._produceWrapper = function (producerInstance, topicName,
-  partition, value, key, optOpaque) {
+  partition, value, key, timestamp, optOpaque) {
 
   if (!this.sr.valueSchemas[topicName]) {
     // topic not found in schemas, bail early
@@ -83,7 +84,7 @@ Producer.prototype._produceWrapper = function (producerInstance, topicName,
 
     var bufVal = new Buffer(JSON.stringify(value));
     return producerInstance.__kafkaAvro_produce(topicName, partition, bufVal,
-      key, optOpaque);
+      key, timestamp, optOpaque);
   }
 
   var type = this.sr.valueSchemas[topicName];
@@ -92,7 +93,7 @@ Producer.prototype._produceWrapper = function (producerInstance, topicName,
   var bufValue = this.serialize(type, schemaId, value);
 
   return producerInstance.__kafkaAvro_produce(topicName, partition, bufValue,
-    key, optOpaque);
+    key, timestamp, optOpaque);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-avro",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "main": "./lib/kafka-avro",
   "description": "Node.js bindings for librdkafka with Avro schema serialization.",
   "homepage": "https://github.com/waldophotos/kafka-avro",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-avro",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "./lib/kafka-avro",
   "description": "Node.js bindings for librdkafka with Avro schema serialization.",
   "homepage": "https://github.com/waldophotos/kafka-avro",

--- a/test/spec/consumer.test.js
+++ b/test/spec/consumer.test.js
@@ -119,6 +119,29 @@ describe('Consume', function() {
       }, 10000);
     });
 
+    it('should produce and consume a message using consume "on" with timestamp when provided', function(done) {
+      var produceTime = Date.parse('04 Dec 2015 00:12:00 GMT'); //use date in the past to guarantee we don't get Date.now()
+
+      var message = {
+        name: 'Thanasis',
+        long: 540,
+      };
+
+      // //start consuming messages
+      this.consumer.subscribe([testLib.topic]);
+      this.consumer.consume();
+
+      this.consumer.on('data', function(rawData) {
+        expect(rawData.timestamp).to.equal(produceTime);
+        done();
+      }.bind(this));
+
+      setTimeout(() => {
+        produceTime = Date.now();
+        this.producer.produce(testLib.topic, -1, message, 'key', produceTime);
+      }, 10000);
+    });
+
     it('should produce and consume a message using consume "on", on a non Schema Registry topic', function(done) {
       var produceTime = 0;
 


### PR DESCRIPTION
Fixes a problem with `kafka-producer.js` where it was calling the underlying library with the wrong parameters for timestamp and opaque.

Adds regression tests for both producing (for opaque value) and consuming (for the timestamp value).