### PR TITLE
Adding fetchRefreshRate option to SchemaRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ You can use `docker-compose up` to up all the stack before you call your integra
 
 ## Release History
 
-- **1.0.6**, *06 July 2018*
+- **1.0.6**, *11 July 2018*
     - Adding the `fetchRefreshRate` parameter, to set a way to update the schemas after the app initialization. (by [ricardohbin](https://github.com/ricardohbin))
 - **1.0.5**, *27 June 2018*
     - Fixes kafka-producer to pass timestamp and opaque correctly (by [javierholguera](https://github.com/javierholguera))

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When instantiating kafka-avro you may pass the following options:
 * `schemaRegistry` **String REQUIRED** The url to the Schema Registry.
 * `topics` **Array of Strings** You may optionally define specific topics to be fetched by kafka-avro vs fetching schemas for all the topics which is the default behavior.
 * `fetchAllVersions` **Boolean** Set to true to fetch all versions for each topic, use it when updating of schemas is often in your environment.
+* `fetchRefreshRate` **Number** The pooling time (in seconds) to the schemas be fetched and updated in background. This is useful to keep with schemas changes in production. The default value is `0` seconds (disabled).
 * `parseOptions` **Object** Schema parse options to pass to `avro.parse()`. `parseOptions.wrapUnions` is set to `true` by default.
 * `httpsAgent` **Object** initialized [https Agent class](https://nodejs.org/api/https.html#https_class_https_agent)
 
@@ -272,6 +273,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
 
 ## Release History
 
+- **1.0.6**, *06 July 2018*
+    - Adding the `fetchRefreshRate` parameter, to set a way to update the schemas after the app initialization. (by [ricardohbin](https://github.com/ricardohbin))
 - **1.0.5**, *27 June 2018*
     - Fixes kafka-producer to pass timestamp and opaque correctly (by [javierholguera](https://github.com/javierholguera))
 - **1.0.4**, *30 May 2018*

--- a/lib/kafka-avro.js
+++ b/lib/kafka-avro.js
@@ -45,6 +45,7 @@ var KafkaAvro = module.exports = CeventEmitter.extend(function(opts) {
     schemaRegistryUrl: opts.schemaRegistry,
     selectedTopics: opts.topics || null,
     fetchAllVersions: opts.fetchAllVersions || false,
+    fetchRefreshRate: opts.fetchRefreshRate || 0,
     parseOptions: opts.parseOptions,
     httpsAgent: opts.httpsAgent
   };

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -106,7 +106,12 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
       log.warn('_onWrapper() :: Warning, consumer did not find topic on SR:',
         message.topic);
 
-      message.parsed = JSON.parse(message.value.toString('utf-8'));
+      try {
+        message.parsed = JSON.parse(message.value.toString('utf-8'));
+      } catch (ex) {
+        log.warn('_onWrapper() :: Error parsing value:', message.value,
+          'Error:', ex);
+      }
 
       cb(message);
       return;

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -106,12 +106,7 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
       log.warn('_onWrapper() :: Warning, consumer did not find topic on SR:',
         message.topic);
 
-      try {
-        message.parsed = JSON.parse(message.value.toString('utf-8'));
-      } catch (ex) {
-        log.warn('_onWrapper() :: Error parsing value:', message.value,
-          'Error:', ex);
-      }
+      message.parsed = JSON.parse(message.value.toString('utf-8'));
 
       cb(message);
       return;

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -44,6 +44,9 @@ var SchemaRegistry = module.exports = cip.extend(function(opts) {
     this.parseOptions.wrapUnions = true;
   }
 
+  /** @type {?Number} The refresh time (in seconds) that the schema registry will be fetch */
+  this.fetchRefreshRate = opts.fetchRefreshRate;
+
   /**
    * A dict containing all the value schemas with key the bare topic name and
    * value the instance of the "avsc" package.
@@ -88,15 +91,10 @@ var SchemaRegistry = module.exports = cip.extend(function(opts) {
  */
 SchemaRegistry.prototype.init = Promise.method(function () {
   log.info('init() :: Initializing SR, will fetch all schemas from SR...');
-
-  return this._fetchTopics()
-    .bind(this)
-    .then(this._storeTopics)
-    .map(this._fetchLatestVersion, { concurrency: 10 })
-    .filter(Boolean)
-    .map(this._fetchSchema, { concurrency: 10 })
-    .map(this._registerSchemaLatest)
-    .then(this._checkForAllVersions);
+  if (this.fetchRefreshRate > 0) {
+    setInterval(this._fetchSchemas.bind(this), this.fetchRefreshRate * 1000);
+  }
+  return this._fetchSchemas();
 });
 
 /**
@@ -411,4 +409,21 @@ SchemaRegistry.prototype._suppressAxiosError = function (err) {
     'Error:', err.message, 'Url:', err.config.url);
 
   return null;
+};
+
+/**
+ * Fetch schemas and register them locally.
+ *
+ * @return {Promise(Array.<Object>)} A promise with the registered schemas.
+ * @private
+ */
+SchemaRegistry.prototype._fetchSchemas = function () {
+  log.debug('_fetchSchemas() :: Schemas refreshed');
+  return this._fetchTopics()
+    .bind(this)
+    .then(this._storeTopics)
+    .map(this._fetchLatestVersion, { concurrency: 10 })
+    .filter(Boolean)
+    .map(this._fetchSchema, { concurrency: 10 })
+    .map(this._registerSchemaLatest);
 };


### PR DESCRIPTION
The strategy that kafka-avro uses to deal with schemas are a full load in memory. This PR adds the possibility to set a refresh rate to schemas fetch - before, the schemas are only loaded when init.

This is not the best strategy at all - cached requests dealing with schemas on demand is a better option. But, to add this option we need to do a major refactoring. And some users are having problems with it.

So, let's add this option for now - the full code refactoring and the new strategy will come in the next major release.

Fixes https://github.com/waldophotos/kafka-avro/issues/41