### PR TITLE
Get info for key schemas also

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
 
 ## Release History
 
+- **1.1.1**, *23 August 2018*
+    - Set `schemaMeta` for key schemas also (by [eparreno](https://github.com/eparreno))
 - **1.1.0**, *06 August 2018*
     - Updating to node-rdkafka v2.3.4 (by [ricardohbin](https://github.com/ricardohbin))
 - **1.0.6**, *11 July 2018*

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -364,10 +364,10 @@ SchemaRegistry.prototype._registerSchemaLatest = Promise.method(function (schema
   if (schemaObj.schemaType.toLowerCase() === 'value') {
     this.schemaTypeById['schema-' + schemaObj.responseRaw.id] = schemaObj.type;
     this.valueSchemas[schemaObj.topic] = schemaObj.type;
-    this.schemaMeta[schemaObj.topic] = schemaObj.responseRaw;
   } else {
     this.keySchemas[schemaObj.topic] = schemaObj.type;
   }
+  this.schemaMeta[schemaObj.topic] = schemaObj.responseRaw;
   return schemaObj;
 });
 

--- a/test/spec/schema-registry.test.js
+++ b/test/spec/schema-registry.test.js
@@ -44,18 +44,16 @@ describe('Initialization of SR', function() {
         if (res.schemaType.toLowerCase() === 'value') {
           expect(sr.schemaTypeById['schema-' + res.responseRaw.id]).to.be.an('object');
           expect(sr.valueSchemas[res.topic]).to.be.an('object');
-          expect(sr.schemaMeta[res.topic]).to.be.an('object');
-
-          expect(sr.schemaMeta[res.topic]).to.have.keys([
-            'subject',
-            'version',
-            'id',
-            'schema',
-          ]);
-
         } else {
           expect(sr.keySchemas[res.topic]).to.be.an('object');
         }
+        expect(sr.schemaMeta[res.topic]).to.be.an('object');
+        expect(sr.schemaMeta[res.topic]).to.have.keys([
+          'subject',
+          'version',
+          'id',
+          'schema',
+        ]);
       })
       .then((all) => {
         expect(all).to.have.length.of.at.least(1);


### PR DESCRIPTION
You're assuming only value schemas will use a schema registry but some people might use a key schema, as we're doing.
When using a key schema `kafka-avro` will not set the `schemaMeta` so no info regarding the schema is available.
https://github.com/waldophotos/kafka-avro/blob/master/lib/schema-registry.js#L368

The main motivation of this PR is to store the schema info to end up allowing key schemas to be used with `kafka-avro` which is not possible at the moment.

That PR is not enough though, next steps should be fixing these lines, one step at a time ;)
https://github.com/waldophotos/kafka-avro/blob/master/lib/kafka-producer.js#L79
https://github.com/waldophotos/kafka-avro/blob/master/lib/kafka-consumer.js#L105