### PR TITLE
Adding "fetch all versions" back

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
 
 ## Release History
 
+- **1.1.3**, *02 January 2019*
+    - Fixing broken `fetchAllVersions` feature (by [ricardohbin](https://github.com/ricardohbin))
 - **1.1.2**, *08 November 2018*
     - Handle topics which use identical schemas (by [scottwd9](https://github.com/scottwd9))
 - **1.1.1**, *23 August 2018*

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -441,5 +441,6 @@ SchemaRegistry.prototype._fetchSchemas = function () {
     .map(this._fetchLatestVersion, { concurrency: 10 })
     .filter(Boolean)
     .map(this._fetchSchema, { concurrency: 10 })
-    .map(this._registerSchemaLatest);
+    .map(this._registerSchemaLatest)
+    .then(this._checkForAllVersions);
 };


### PR DESCRIPTION
When the feature that allows refresh rate was released, the `_checkForAllVersion` method was removed (https://github.com/waldophotos/kafka-avro/pull/42/files#diff-f1df90835d08fdef1a9efce902948d9fL99).

This PR adds back this behavior. Thanks @manikawnth-abg

Fixes https://github.com/waldophotos/kafka-avro/issues/56