### PR TITLE
Update node-rdkafka dependency from ~2.3.4 to ~2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bunyan": "^1.8.5",
     "bunyan-format": "^0.2.1",
     "cip": "^1.0.0",
-    "node-rdkafka": "~2.3.4"
+    "node-rdkafka": "~2.5.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
I had problems with building node-rdkafka ~2.3.4 that were already resolved upstream. It would be ace to have a new release of this package with node-rdkafka updated to the current version.