### PR TITLE
Adds producer option to fail when schema missing

### DIFF
--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -33,7 +33,7 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts, shouldFai
     opts['metadata.broker.list'] = this.kafkaBrokerUrl;
   }
 
-  this.__shouldFailWhenSchemaIsMissing = !!shouldFailWhenSchemaIsMissing;
+  this.__shouldFailWhenSchemaIsMissing = shouldFailWhenSchemaIsMissing === true;
 
   log.info('getProducer() :: Starting producer with options:', opts);
 

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -20,10 +20,11 @@ var Producer = module.exports = cip.extend();
  *
  * @param {Object} opts Producer general options.
  * @param {Object=} topts Producer topic options.
+ * @param {boolean} [shouldFailWhenSchemaIsMissing=false] Whether the producer should fail when no schema was found.
  * @see https://github.com/edenhill/librdkafka/blob/2213fb29f98a7a73f22da21ef85e0783f6fd67c4/CONFIGURATION.md
  * @return {Promise(kafka.Producer)} A Promise.
  */
-Producer.prototype.getProducer = Promise.method(function (opts, topts) {
+Producer.prototype.getProducer = Promise.method(function (opts, topts, shouldFailWhenSchemaIsMissing) {
   if (!opts) {
     opts = {};
   }
@@ -31,6 +32,8 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts) {
   if (!opts['metadata.broker.list']) {
     opts['metadata.broker.list'] = this.kafkaBrokerUrl;
   }
+
+  this.__shouldFailWhenSchemaIsMissing = !!shouldFailWhenSchemaIsMissing;
 
   log.info('getProducer() :: Starting producer with options:', opts);
 
@@ -41,6 +44,7 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts) {
   // hack node-rdkafka
   producer.__kafkaAvro_produce = producer.produce;
   producer.produce = this._produceWrapper.bind(this, producer);
+  producer.setShouldFailWhenSchemaIsMissing = this.setShouldFailWhenSchemaIsMissing.bind(this);
 
   return new Promise(function(resolve, reject) {
     producer.on('ready', function() {
@@ -62,6 +66,13 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts) {
 });
 
 /**
+ * @param {boolean} shouldFail Whether the producer should fail when no schema was found.
+ */
+Producer.prototype.setShouldFailWhenSchemaIsMissing = function(shouldFail) {
+  this.__shouldFailWhenSchemaIsMissing = shouldFail;
+};
+
+/**
  * Avro serialization helper.
  *
  * @param {string=} topicName Name of the topic.
@@ -81,6 +92,12 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
   if (!schema) {
     log.warn('_produceWrapper() :: Warning, did not find topic on SR for ' + schemaType + ' schema:',
       topicName);
+
+    if (this.__shouldFailWhenSchemaIsMissing) {
+      throw new Error(
+        'Unable to serialize message for topic ' + topicName
+        + ' and type ' + schemaType + ': schema not found');
+    }
 
     return (typeof data === 'object')
       ? new Buffer(JSON.stringify(data))

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     {
       "name": "Ricardo Bin",
       "email": "ricardohbin@gmail.com"
+    },
+    {
+      "name": "Marc Löhe",
+      "email": "marcloehe@gmail.com"
     }
   ],
   "repository": {

--- a/test/spec/producer.test.js
+++ b/test/spec/producer.test.js
@@ -113,5 +113,16 @@ describe('Produce', function() {
 
     expect(binded).to.throw(Error);
   });
+  it('should fail when schema is missing and shouldFailWhenSchemaIsMissing is set', function() {
+    var message = {
+      name: 'Thanasis',
+      long: 540,
+    };
+
+    this.producer.setShouldFailWhenSchemaIsMissing(true);
+    var binded = this.producer.produce.bind(this.producer, "topic-without-schema", -1, message, 'key');
+
+    expect(binded).to.throw(Error);
+  });
 
 });


### PR DESCRIPTION
If there is no schema found on the schema registry for a topic's key/value, the producer currently falls back to logging a warning and producing a message as JSON. I think this behaviour is misleading, because I would assume calling `Producer.produce()` without causing an error to mean the message has been successfully serialized and sent which is not the case.

In this PR I added an optional third parameter `shouldFailWhenSchemaIsMissing` to the `KafkaAvro.getProducer()` method. If this is set to true, producing a message will throw an error if no schema can be found for key or value.

I would prefer to have this option set to true by default and require users to explicitly opt out of the current, misleading behavior, this would require a new major release, though - would you consider changing this for 2.x?