### PR TITLE
Revert "Adds producer option to fail when schema missing (#63)"

### DIFF
--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -20,11 +20,10 @@ var Producer = module.exports = cip.extend();
  *
  * @param {Object} opts Producer general options.
  * @param {Object=} topts Producer topic options.
- * @param {boolean} [shouldFailWhenSchemaIsMissing=false] Whether the producer should fail when no schema was found.
  * @see https://github.com/edenhill/librdkafka/blob/2213fb29f98a7a73f22da21ef85e0783f6fd67c4/CONFIGURATION.md
  * @return {Promise(kafka.Producer)} A Promise.
  */
-Producer.prototype.getProducer = Promise.method(function (opts, topts, shouldFailWhenSchemaIsMissing) {
+Producer.prototype.getProducer = Promise.method(function (opts, topts) {
   if (!opts) {
     opts = {};
   }
@@ -32,8 +31,6 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts, shouldFai
   if (!opts['metadata.broker.list']) {
     opts['metadata.broker.list'] = this.kafkaBrokerUrl;
   }
-
-  this.__shouldFailWhenSchemaIsMissing = shouldFailWhenSchemaIsMissing === true;
 
   log.info('getProducer() :: Starting producer with options:', opts);
 
@@ -44,7 +41,6 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts, shouldFai
   // hack node-rdkafka
   producer.__kafkaAvro_produce = producer.produce;
   producer.produce = this._produceWrapper.bind(this, producer);
-  producer.setShouldFailWhenSchemaIsMissing = this.setShouldFailWhenSchemaIsMissing.bind(this);
 
   return new Promise(function(resolve, reject) {
     producer.on('ready', function() {
@@ -66,13 +62,6 @@ Producer.prototype.getProducer = Promise.method(function (opts, topts, shouldFai
 });
 
 /**
- * @param {boolean} shouldFail Whether the producer should fail when no schema was found.
- */
-Producer.prototype.setShouldFailWhenSchemaIsMissing = function(shouldFail) {
-  this.__shouldFailWhenSchemaIsMissing = shouldFail;
-};
-
-/**
  * Avro serialization helper.
  *
  * @param {string=} topicName Name of the topic.
@@ -92,12 +81,6 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
   if (!schema) {
     log.warn('_produceWrapper() :: Warning, did not find topic on SR for ' + schemaType + ' schema:',
       topicName);
-
-    if (this.__shouldFailWhenSchemaIsMissing) {
-      throw new Error(
-        'Unable to serialize message for topic ' + topicName
-        + ' and type ' + schemaType + ': schema not found');
-    }
 
     return (typeof data === 'object')
       ? new Buffer(JSON.stringify(data))

--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
     {
       "name": "Ricardo Bin",
       "email": "ricardohbin@gmail.com"
-    },
-    {
-      "name": "Marc Löhe",
-      "email": "marcloehe@gmail.com"
     }
   ],
   "repository": {

--- a/test/spec/producer.test.js
+++ b/test/spec/producer.test.js
@@ -113,16 +113,5 @@ describe('Produce', function() {
 
     expect(binded).to.throw(Error);
   });
-  it('should fail when schema is missing and shouldFailWhenSchemaIsMissing is set', function() {
-    var message = {
-      name: 'Thanasis',
-      long: 540,
-    };
-
-    this.producer.setShouldFailWhenSchemaIsMissing(true);
-    var binded = this.producer.produce.bind(this.producer, "topic-without-schema", -1, message, 'key');
-
-    expect(binded).to.throw(Error);
-  });
 
 });


### PR DESCRIPTION
When I was updating the documentation with the flag and seeing last checks, I see that this feature violates the concept of `getConsumer`/`getProducer` works exactly node-rdkafka as is. 

@bfncs sorry about this, but your flag need to be reverted.

If you found a way to raise "fail" without changes the signature of `getProducer`, feel free to open other PR.

