### PR TITLE
Adds KafkaAvro option to fail when schema missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ When instantiating kafka-avro you may pass the following options:
 * `fetchRefreshRate` **Number** The pooling time (in seconds) to the schemas be fetched and updated in background. This is useful to keep with schemas changes in production. The default value is `0` seconds (disabled).
 * `parseOptions` **Object** Schema parse options to pass to `avro.parse()`. `parseOptions.wrapUnions` is set to `true` by default.
 * `httpsAgent` **Object** initialized [https Agent class](https://nodejs.org/api/https.html#https_class_https_agent)
+* `shouldFailWhenSchemaIsMissing` **Boolean** Set to true if producing a message for which no AVRO schema can be found should throw an error
 
 ### Producer
 
@@ -274,6 +275,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
     * `grunt release:major` for major number jump.
 
 ## Release History
+- **1.2.1**, *06 Sep 2019*
+    - Adds a new the optional config param `shouldFailWhenSchemaIsMissing` to let the producer fail when no schema could be found (instead of producing as JSON)
 - **1.2.0**, *03 March 2019*
     - Fixed cases when both key and value schemas were available, but the value was being serialized using the key schema (by [macabu](https://github.com/macabu))
     - Support for (de)serialization of keys. Added `parsedKey` and `schemaIdKey` to the consumer data object (by [macabu](https://github.com/macabu))

--- a/lib/kafka-avro.js
+++ b/lib/kafka-avro.js
@@ -53,6 +53,9 @@ var KafkaAvro = module.exports = CeventEmitter.extend(function(opts) {
   /** @type {kafka-avro.SchemaRegistry} Instanciated SR. */
   this.sr = new SchemaRegistry(srOpts);
 
+  /** @type {boolean} Whether the producer should fail when no schema was found. */
+  this._shouldFailWhenSchemaIsMissing = opts.shouldFailWhenSchemaIsMissing === true;
+
   /** @type {Array.<node-rdkafka.Producer>} Instanciated producers. */
   this._producers = [];
   /** @type {Array.<node-rdkafka.Consumer>} Instanciated consumers. */
@@ -119,8 +122,15 @@ KafkaAvro.prototype.dispose = Promise.method(function () {
   });
 
   return Promise.all(disconnectPromises)
-    .then( () => { 
-      if(this.sr._refreshHandle) 
-        clearInterval(this.sr._refreshHandle); 
+    .then( () => {
+      if(this.sr._refreshHandle)
+        clearInterval(this.sr._refreshHandle);
     });
 });
+
+/**
+ * @param {boolean} shouldFail Whether the producer should fail when no schema was found.
+ */
+KafkaAvro.prototype.setShouldFailWhenSchemaIsMissing = function(shouldFail) {
+  this.__shouldFailWhenSchemaIsMissing = shouldFail;
+};

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -82,6 +82,12 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
     log.warn('_produceWrapper() :: Warning, did not find topic on SR for ' + schemaType + ' schema:',
       topicName);
 
+    if (this.__shouldFailWhenSchemaIsMissing) {
+      throw new Error(
+        'Unable to serialize message for topic ' + topicName
+        + ' and type ' + schemaType + ': schema not found');
+    }
+
     return (typeof data === 'object')
       ? new Buffer(JSON.stringify(data))
       : new Buffer(data);
@@ -105,7 +111,7 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
  * @param {*=} optOpaque Pass vars to receipt handler.
  */
 Producer.prototype._produceWrapper = function (producerInstance, topicName,
-  partition, value, key, timestamp, optOpaque) {
+                                               partition, value, key, timestamp, optOpaque) {
   var sendKey = key
     ? this._serializeType(topicName, true, key)
     : null;

--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
     {
       "name": "Ricardo Bin",
       "email": "ricardohbin@gmail.com"
-    },
-    {
-      "name": "Marc Löhe",
-      "email": "marcloehe@gmail.com"
     }
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     {
       "name": "Ricardo Bin",
       "email": "ricardohbin@gmail.com"
+    },
+    {
+      "name": "Marc Löhe",
+      "email": "marcloehe@gmail.com"
     }
   ],
   "repository": {

--- a/test/spec/producer.test.js
+++ b/test/spec/producer.test.js
@@ -113,5 +113,16 @@ describe('Produce', function() {
 
     expect(binded).to.throw(Error);
   });
+  it('should fail when schema is missing and shouldFailWhenSchemaIsMissing is set', function() {
+    var message = {
+      name: 'Thanasis',
+      long: 540,
+    };
+
+    this.kafkaAvro.setShouldFailWhenSchemaIsMissing(true);
+    var binded = this.producer.produce.bind(this.producer, "topic-without-schema", -1, message, 'key');
+
+    expect(binded).to.throw(Error);
+  });
 
 });


### PR DESCRIPTION
This is a follow up to #63 which was reverted by #65.

If there is no schema found on the schema registry for a topic's key/value, the producer currently falls back to logging a warning and producing a message as JSON. I think this behaviour is misleading, because I would assume calling Producer.produce() without causing an error to mean the message has been successfully serialized and sent which is not the case.

In this PR I added an optional options property `shouldFailWhenSchemaIsMissing` to the KafkaAvro() constructor. If this is set to true, producing a message will throw an error if no schema can be found for key or value.

I would still prefer to have this option set to true by default and require users to explicitly opt out of the current, misleading behavior, this would require a new major release, though - would you consider adding this for 2.x?