### PR TITLE
Updating node-rdkafka to librdkafka 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
     * `grunt release:major` for major number jump.
 
 ## Release History
+- **2.0.0**, *04 September 2019*
+    - **Breaking change** Update version of node-rdkafka to ~v2.7.1 - this version uses `librdkafka` v1.1.0
 - **1.2.0**, *03 March 2019*
     - Fixed cases when both key and value schemas were available, but the value was being serialized using the key schema (by [macabu](https://github.com/macabu))
     - Support for (de)serialization of keys. Added `parsedKey` and `schemaIdKey` to the consumer data object (by [macabu](https://github.com/macabu))

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bunyan": "^1.8.5",
     "bunyan-format": "^0.2.1",
     "cip": "^1.0.0",
-    "node-rdkafka": "~2.3.4"
+    "node-rdkafka": "~2.7.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
These dependencies are a bit old. This PR and the new release updates them.

I will publish this as major version because the previous version of librdkafka we are using is 0.11.4