### PR TITLE
Fixing strategy to key/value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 addons:
   hosts:
     - kafka
+    - schema-registry
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get -y install libsasl2-dev libssl-dev

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
     * `grunt release:major` for major number jump.
 
 ## Release History
+- **3.0.1**, *03 Jan 2020*
+    - Fix a bug to custom strategies `keySubjectStrategy` and `valueSubjectStrategy` - they were not working as expected. The default behavior was not impacted.
 - **3.0.0**, *19 Sep 2019* 
     - Adds support for `RecordNameStrategy`(io.confluent.kafka.serializers.subject.RecordNameStrategy) and `TopicRecordNameStrategy`(io.confluent.kafka.serializers.subject.TopicRecordNameStrategy)
 schema subject name strategy. The purpose of the new strategies is to allow to put several event types in the same kafka topic (https://www.confluent.io/blog/put-several-event-types-kafka-topic) (by [pleszczy](github.com/pleszczy))

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Deserialize the provided message, expects a message that includes Magic Byte and
 You can use `docker-compose up` to up all the stack before you call your integration tests with `npm test`. How the integration tests are outside the containers, you will need set you `hosts` file to :
 
 ```
-127.0.0.1 kafka
+127.0.0.1 kafka schema-registry
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,9 @@ You can use `docker-compose up` to up all the stack before you call your integra
     * `grunt release:major` for major number jump.
 
 ## Release History
-- **3.0.1**, *03 Jan 2020*
+- **3.0.1**, *13 Jan 2020*
     - Fix a bug to custom strategies `keySubjectStrategy` and `valueSubjectStrategy` - they were not working as expected. The default behavior was not impacted.
+    - Little error logs improvements
 - **3.0.0**, *19 Sep 2019* 
     - Adds support for `RecordNameStrategy`(io.confluent.kafka.serializers.subject.RecordNameStrategy) and `TopicRecordNameStrategy`(io.confluent.kafka.serializers.subject.TopicRecordNameStrategy)
 schema subject name strategy. The purpose of the new strategies is to allow to put several event types in the same kafka topic (https://www.confluent.io/blog/put-several-event-types-kafka-topic) (by [pleszczy](github.com/pleszczy))

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When instantiating kafka-avro you may pass the following options:
 * `httpsAgent` **Object** initialized [https Agent class](https://nodejs.org/api/https.html#https_class_https_agent)
 * `shouldFailWhenSchemaIsMissing` **Boolean** Set to true if producing a message for which no AVRO schema can be found should throw an error
 * `keySubjectStrategy` **String** A SubjectNameStrategy for key. It is used by the Avro serializer to determine the subject name under which the event record schemas should be registered in the schema registry. The default is TopicNameStrategy. Allowed values are [TopicRecordNameStrategy, TopicNameStrategy, RecordNameStrategy]
-* `valueSubjectStrategy` **String** **String** A SubjectNameStrategy for value. It is used by the Avro serializer to determine the subject name under which the event record schemas should be registered in the schema registry. The default is TopicNameStrategy. Allowed values are [TopicRecordNameStrategy, TopicNameStrategy, RecordNameStrategy]
+* `valueSubjectStrategy` **String** A SubjectNameStrategy for value. It is used by the Avro serializer to determine the subject name under which the event record schemas should be registered in the schema registry. The default is TopicNameStrategy. Allowed values are [TopicRecordNameStrategy, TopicNameStrategy, RecordNameStrategy]
 
 ### Producer
 

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -75,12 +75,11 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
   let subject = null;
 
   if (isKey === false) {
-    subject = this.sr.keySubjectStrategy.prepareSubjectName(topicName, data);
+    subject = this.sr.valueSubjectStrategy.prepareSubjectName(topicName, data);
     schema = this.sr.valueSchemas[subject];
   } else {
-    subject = this.sr.valueSubjectStrategy.prepareSubjectName(topicName, data);
+    subject = this.sr.keySubjectStrategy.prepareSubjectName(topicName, data);
     schema = this.sr.keySchemas[subject];
-
   }
 
   const schemaType = isKey === false
@@ -91,7 +90,8 @@ Producer.prototype._serializeType = function (topicName, isKey, data) {
     log.warn('_produceWrapper() :: Warning, did not find topic on SR for subject schema:',
       {
         topic: topicName,
-        subject: subject
+        subject: subject,
+        schemaType,
       });
 
     if (this.__shouldFailWhenSchemaIsMissing) {

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -52,8 +52,8 @@ const SchemaRegistry = module.exports = cip.extend(function (opts) {
    * Compatibility checks are per subject
    * Versions are tied to subjects
    * When schemas evolve, they are still associated to the same subject but get a new schema id and version
-   *Overview
-   *The subject name depends on the subject name strategy, which you can set to one of the following three values:
+   * Overview
+   * The subject name depends on the subject name strategy, which you can set to one of the following three values:
    *
    * *TopicNameStrategy* (io.confluent.kafka.serializers.subject.TopicNameStrategy) – this is the default
    * *RecordNameStrategy* (io.confluent.kafka.serializers.subject.RecordNameStrategy)
@@ -68,8 +68,8 @@ const SchemaRegistry = module.exports = cip.extend(function (opts) {
    * Compatibility checks are per subject
    * Versions are tied to subjects
    * When schemas evolve, they are still associated to the same subject but get a new schema id and version
-   *Overview
-   *The subject name depends on the subject name strategy, which you can set to one of the following three values:
+   * Overview
+   * The subject name depends on the subject name strategy, which you can set to one of the following three values:
    *
    * *TopicNameStrategy* (io.confluent.kafka.serializers.subject.TopicNameStrategy) – this is the default
    * *RecordNameStrategy* (io.confluent.kafka.serializers.subject.RecordNameStrategy)


### PR DESCRIPTION
Version 3.0.0 added support to differente strategies - but they have a bug. The good point is that they have very specific uses, so the default implementation "TopicNameStrategy" is not impacted.

I also adding a log the type of schemaType to better warning purposes.