### PR TITLE
stack trace of error are not kept

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -39,7 +39,7 @@ Consumer.prototype.getConsumer = Promise.method(function (opts, topicOpts) {
   });
 
   consumer.on('error', function (err) {
-    log.error({err}, 'getConsumer() :: Consumer Error event fired');
+    log.error(err, 'getConsumer() :: Consumer Error event fired');
   });
 
   // hack node-rdkafka
@@ -75,7 +75,7 @@ Consumer.prototype.getConsumerStream = Promise.method(function (opts, topicOpts,
   });
 
   consumer.on('error', function (err) {
-    log.error({err}, 'getConsumerStream() :: Consumer Error event fired');
+    log.error(err, 'getConsumerStream() :: Consumer Error event fired');
   });
 
   // hack node-rdkafka
@@ -106,7 +106,7 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
       message.parsedKey = keyDecoded.value;
       message.schemaIdKey = keyDecoded.schemaId;
     } catch (err) {
-      log.warn({err}, '_onWrapper() :: Warning, consumer did not find topic on SR for key schema',
+      log.warn(err, '_onWrapper() :: Warning, consumer did not find topic on SR for key schema',
         {topic: message.topic});
 
       const {key} = message;
@@ -119,7 +119,7 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
           if (err instanceof SyntaxError) {
             message.parsedKey = key.toString();
           } else {
-            log.warn({err}, '_onWrapper() :: Error parsing key', {key});
+            log.warn(err, '_onWrapper() :: Error parsing key', {key});
           }
         }
       }
@@ -131,7 +131,7 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
       message.schemaId = valueDecoded.schemaId;
       cb(message);
     } catch (err) {
-      log.warn({err}, '_onWrapper() :: Warning, consumer did not find topic on SR for value schema',
+      log.warn(err, '_onWrapper() :: Warning, consumer did not find topic on SR for value schema',
         {topic: message.topic});
 
       if (message.value) {
@@ -143,7 +143,7 @@ Consumer.prototype._onWrapper = function (consumerInstance, eventName, cb) {
           if (err instanceof SyntaxError) {
             message.parsed = message.value.toString();
           } else {
-            log.warn({err}, '_onWrapper() :: Error parsing value', {value: message.value});
+            log.warn(err, '_onWrapper() :: Error parsing value', {value: message.value});
           }
         }
       }

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -50,7 +50,7 @@ Producer.prototype.getProducer = Promise.method(function (opts, topicOptions) {
 
     producer.connect({}, function (err) {
       if (err) {
-        log.error({err}, 'getProducer() :: Connect failed:');
+        log.error(err, 'getProducer() :: Connect failed:');
         reject(err);
         return;
       }

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -380,7 +380,7 @@ SchemaRegistry.prototype._registerSchema = Promise.method(function (schemaObj) {
   try {
     schemaObj.type = typeFromSchemaResponse(schemaObj.responseRaw.schema, this.parseOptions);
   } catch (err) {
-    log.warn({err}, '_registerSchema() :: Error parsing schema, moving on...',
+    log.warn(err, '_registerSchema() :: Error parsing schema, moving on...',
       {schema: schemaObj});
     return schemaObj;
   }
@@ -407,7 +407,7 @@ SchemaRegistry.prototype._registerSchemaLatest = Promise.method(function (schema
   try {
     schemaObj.type = typeFromSchemaResponse(schemaObj.responseRaw.schema, this.parseOptions);
   } catch (err) {
-    log.warn({err}, '_registerSchemaLatest() :: Error parsing schema, moving on...',
+    log.warn(err, '_registerSchemaLatest() :: Error parsing schema, moving on...',
       {schema: schemaObj});
     return schemaObj;
   }
@@ -440,7 +440,7 @@ SchemaRegistry.prototype._handleAxiosError = function (err) {
     throw err;
   }
 
-  log.warn({err}, '_handleAxiosError() :: http error: message, url', {
+  log.warn(err, '_handleAxiosError() :: http error: message, url', {
     message: err.message,
     url: err.config.url
   });
@@ -463,7 +463,7 @@ SchemaRegistry.prototype._suppressAxiosError = function (err) {
     throw err;
   }
 
-  log.debug({err}, '_suppressAxiosError() :: http error for url, will continue operation.',
+  log.debug(err, '_suppressAxiosError() :: http error for url, will continue operation.',
     {
       error: err.message,
       url: err.config.url

--- a/test/lib/test.lib.js
+++ b/test/lib/test.lib.js
@@ -130,7 +130,7 @@ testLib.registerSchema = Promise.method(function (topic, schema, type, retries) 
     data: data,
   })
     .catch(function (err) {
-      testLib.log.error({err}, 'Axios SR creation failed after noOfRetries', {noOfRetries: retries});
+      testLib.log.error(err, 'Axios SR creation failed after noOfRetries', {noOfRetries: retries});
       retries++;
 
       if (retries > 20) {


### PR DESCRIPTION
When an error is logged via bunyan with a prent cause, this parent cause is not written correctly.

According to https://github.com/trentm/node-bunyan/tree/1.x#log-method-api a parent cause should not be logged as 
```javascript
log.warn({err}, '_onWrapper() :: Error parsing value', {value: message.value});
```
but as 
```javascript
log.warn(err, '_onWrapper() :: Error parsing value', {value: message.value});
```
