### PR TITLE
Add isStringRegistryKey boolean option to allow having simple string keys instead of Avro keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ When instantiating kafka-avro you may pass the following options:
 * `shouldFailWhenSchemaIsMissing` **Boolean** Set to true if producing a message for which no AVRO schema can be found should throw an error
 * `keySubjectStrategy` **String** A SubjectNameStrategy for key. It is used by the Avro serializer to determine the subject name under which the event record schemas should be registered in the schema registry. The default is TopicNameStrategy. Allowed values are [TopicRecordNameStrategy, TopicNameStrategy, RecordNameStrategy]
 * `valueSubjectStrategy` **String** A SubjectNameStrategy for value. It is used by the Avro serializer to determine the subject name under which the event record schemas should be registered in the schema registry. The default is TopicNameStrategy. Allowed values are [TopicRecordNameStrategy, TopicNameStrategy, RecordNameStrategy]
+* `isStringRegistryKey` **Boolean** Set to true to not send requests for Avro schemas for keys. Set to `false` by default
 
 ### Producer
 
@@ -301,6 +302,8 @@ You can use `docker-compose up` to up all the stack before you call your integra
     * `grunt release:major` for major number jump.
 
 ## Release History
+- **3.0.3**, *15 May 2020*
+    - Adds support for string type schema registry keys parameter, feature by [OleksandrKrupko](github.com/OleksandrKrupko).
 - **3.0.2**, *14 Jan 2020*
     - Adds support for basic authentication to schema registry, using Axios auth Request Config parameter, feature by [Bookaway](github.com/Bookaway).
 - **3.0.1**, *13 Jan 2020*

--- a/lib/kafka-avro.js
+++ b/lib/kafka-avro.js
@@ -46,6 +46,7 @@ const KafkaAvro = module.exports = CeventEmitter.extend(function (opts) {
     schemaRegistryUrl: opts.schemaRegistry,
     auth: opts.schemaRegistryAuth || null,
     selectedTopics: opts.topics || null,
+    isStringRegistryKey: opts.isStringRegistryKey || false,
     fetchAllVersions: opts.fetchAllVersions || false,
     fetchRefreshRate: opts.fetchRefreshRate || 0,
     parseOptions: opts.parseOptions,

--- a/lib/schema-registry.js
+++ b/lib/schema-registry.js
@@ -43,6 +43,9 @@ const SchemaRegistry = module.exports = cip.extend(function (opts) {
   /** @type {Array.<string>|null} The user selected topics to fetch, can be null */
   this.selectedTopics = opts.selectedTopics;
 
+  /** @type {boolean} Is a string key. Defines the need to download a key schema */
+  this.isStringRegistryKey = opts.isStringRegistryKey;
+
   /** @type {boolean} Fetch all versions for each topic. */
   this.fetchAllVersions = opts.fetchAllVersions;
 
@@ -246,10 +249,13 @@ SchemaRegistry.prototype._storeTopics = Promise.method(function (schemaTopics) {
  */
 SchemaRegistry.prototype._processSelectedTopics = Promise.method(function () {
   const topics = [];
+  const self = this;
 
   this.selectedTopics.forEach(function (selectedTopic) {
     topics.push(selectedTopic + '-value');
-    topics.push(selectedTopic + '-key');
+    if (!self.isStringRegistryKey) {
+      topics.push(selectedTopic + '-key');
+    }
   });
 
   return topics;
@@ -298,7 +304,6 @@ SchemaRegistry.prototype._fetchLatestVersion = Promise.method(function (schemaTo
     .then((response) => {
       log.debug('_fetchLatestVersion() :: Fetched latest topic version from url:',
         fetchLatestVersionUrl);
-
       return {
         version: response.data.version,
         schemaTopic: schemaTopic,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-avro",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "./lib/kafka-avro",
   "description": "Node.js bindings for librdkafka with Avro schema serialization.",
   "homepage": "https://github.com/waldophotos/kafka-avro",


### PR DESCRIPTION
The purpose of this update is to allow having simple string keys instead of Avro keys. Because right now, we have simple string keys and failed requests, because the lib tries to get key schemas which are don't exist. In a large scale, it's a lot of failed requests