### PR TITLE
Update the usage of enable.auto.commit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ When consuming topics using the `data` event you will need to perform a `connect
 ```js
 kafkaAvro.getConsumer({
   'group.id': 'librd-test',
-  'socket.keepalive.enable': true,
+  'socket.keepalive.enable': true
+},
+{
   'enable.auto.commit': true,
 })
   // the "getConsumer()" method will return a bluebird promise.


### PR DESCRIPTION
Move the enable.auto.commit from the global config to the topic config.

Refer to https://github.com/edenhill/librdkafka/blob/2213fb29f98a7a73f22da21ef85e0783f6fd67c4/CONFIGURATION.md